### PR TITLE
Add RSS feed as alternate link in head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,6 +33,7 @@ const socialImageURL = new URL(
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
+    <link rel="alternate" href="/rss.xml" type="application/rss+xml" title="RSS">
     <meta name="generator" content={Astro.generator} />
 
     <!-- General Meta Tags -->


### PR DESCRIPTION
I was able to figure out where your RSS feed was from the source code here on GitHub, but I imagine it would be helpful if you had something like this in your `<head>`.