### PR TITLE
Fix the link to RSS

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -46,4 +46,4 @@ console.log(heroImage);
 
 <link rel="alternate" type="application/rss+xml" 
   title="RSS Feed for olliewilliams.xyz" 
-  href="/rss/" />
+  href="/rss.xml" />


### PR DESCRIPTION
Otherwise, it’s 404, and it’s hard to guess that it’s `/rss.xml`, not `/rss/`.

Thanks to [the previous PR’s](https://github.com/o-t-w/blog/pull/1) author for the hint ;)